### PR TITLE
Add support for `object` un/marshalling

### DIFF
--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -32,6 +32,7 @@ export const defaultMarshaller: Marshaller< any > = (value: any, json: Json, cla
 
 export const defaultUnmarshaller: Unmarshaller< any > = (value: JsValue, json: Json, clazz: any, classPropertyName: string, jsonPropertyName: string, target: Function, mbType: Optional< Function >, jsonPath: string[], classPath: string[]) => {
 
+
     // if the value is not define
     if (!isDefined(value)) {
 
@@ -58,6 +59,10 @@ export const defaultUnmarshaller: Unmarshaller< any > = (value: JsValue, json: J
             return type.prototype.constructor.fromJsObject(value, jsonPath, classPath);
         }
 
+        if (type === Object) {
+            return objectUnmarshaller(value, json, clazz, classPropertyName, jsonPropertyName, target, mbType, jsonPath, classPath);
+        }
+
         const additionalMessage = `No unmarshaller found for type ${type['name']}`;
         return Left< UnmarshallError[], number >([new UnmarshallError(value, Some(type), jsonPropertyName, classPropertyName, target, jsonPath, classPath, Some(additionalMessage))]);
     });
@@ -82,4 +87,12 @@ const numberUnmarshaller: Unmarshaller< number > = (value: JsValue, json: Json, 
     }
     const additionalErrorMessage = Some("The value is not a number value.");
     return Left< UnmarshallError[], number >([new UnmarshallError(value, Some(Number), jsonPropertyName, classPropertyName, target, jsonPath, classPath, additionalErrorMessage)]);
+};
+
+const objectUnmarshaller: Unmarshaller< object > = (value: JsValue, json: Json, clazz: any, classPropertyName: string, jsonPropertyName: string, target: Function, mbType: Optional< Function >, jsonPath: string[], classPath: string[]) => {
+    if (typeof value === 'object') {
+        return Right< UnmarshallError[], object >(value as object);
+    }
+    const additionalErrorMessage = Some("The value is not an object.");
+    return Left< UnmarshallError[], object >([new UnmarshallError(value, Some(Object), jsonPropertyName, classPropertyName, target, jsonPath, classPath, additionalErrorMessage)]);
 };

--- a/test/Serialize.ts
+++ b/test/Serialize.ts
@@ -15,10 +15,14 @@ describe('ts-serialize', () => {
         @SerializeOpt( String )
         public name : Optional< string >;
 
-        constructor(id : string, name : Optional< string > = None) {
+        @SerializeOpt( Object )
+        public metadata: Optional< object >;
+
+        constructor(id : string, name : Optional< string > = None, metadata : Optional< object > = None) {
             super();
             this.id = id;
             this.name = name;
+            this.metadata = metadata;
         }
     }
 
@@ -72,7 +76,10 @@ describe('ts-serialize', () => {
             name  : 'Jane',
             age   : 18,
             role: {
-                id: '123456'
+                id: '123456',
+                metadata: { 
+                  foo: "bar"
+                }
             },
         }],
         role: {
@@ -93,7 +100,8 @@ describe('ts-serialize', () => {
              children : [],
              role: {
                 id: '123456',
-                name : null
+                name : null,
+                metadata: null
              },
         }, {
              _id   : 'daughter',
@@ -103,16 +111,20 @@ describe('ts-serialize', () => {
              children : [],
              role: {
                 id: '123456',
-                name : null
+                name : null,
+                metadata: { 
+                  foo: "bar"
+                }
              },
         }],
         role: {
             id: '123456',
-            name : null
+            name : null,
+            metadata : null
         },
     };
 
-    const referenceUser = new User(json._id, Some(json.name), +json.age, new Role("123456"), [ new User("son", Some("David"), 13, new Role("123456")), new User("daughter", Some("Jane"), 18, new Role("123456")) ]);
+    const referenceUser = new User(json._id, Some(json.name), +json.age, new Role("123456"), [ new User("son", Some("David"), 13, new Role("123456")), new User("daughter", Some("Jane"), 18, new Role("123456", None, Some( { foo: "bar" } ))) ]);
     const mbUsersFromJson = User.fromStringAsArray< User >(JSON.stringify([json]));
 
     mbUsersFromJson.fold< void >( errors => errors.forEach( e => console.error(e) ), json => console.log(json) );


### PR DESCRIPTION
Closes #1 

Support un/marshalling of `object` types which are not declared serializable.